### PR TITLE
Add zip & unzip to the packages list

### DIFF
--- a/39/gnome-minimal.ks
+++ b/39/gnome-minimal.ks
@@ -25,6 +25,8 @@ gnome-user-share
 nautilus
 plymouth-system-theme
 yelp
+zip                                    # zip and unzip are required by the ExtensionsManager
+unzip                                  # otherwise installation of Extensions won't work
 %end
 
 %post


### PR DESCRIPTION
Hey there!

First of, I highly appreciate this repo!

The reason for the PR is:
_**The Gnome ExtensionManager uses unzip to extract the downloaded extensions. Without unzip any attempt to install extensions will silently fail.**_

I observed this behavior after using the kickstart for Fedora 39. The GUI of the ExtensionManager won't report any issues. Just after clicking on any extension...nothing happens. Only the logs (when starting from terminal) will expose the missing `unzip`.

Also weird:
Both [Ubuntu](https://packages.ubuntu.com/mantic-updates/gnome-shell) and [Debian](https://packages.debian.org/sid/gnome-shell) are listing `unzip` as recommended package for `gnome-shell`, but [Fedora](https://packages.fedoraproject.org/pkgs/gnome-shell/gnome-shell/fedora-39-updates.html#dependencies) **does not**.

cheers
flash ⚡